### PR TITLE
Fix dpm-query path (fix #1), better metadata.json, don't use pkexec if not needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-Sample Screenshot: http://i.imgur.com/ck8AyyF.png
+Radeon DPM Control
+==================
 
-# radeon-dpm-control
+![Sample Screenshot](http://i.imgur.com/ck8AyyF.png)
+
 A GNOME3 extension to manually set Radeon's DPM state and level. Also includes a status indicator that shows the current setting.
 
 The indicator shows a green, yellow or red Radeon symbol when the DPM settings are low/battery, auto/balanced or high/performance, respectively. Any other combination will make a yellow '?' show up. A red '!' indicates that the DPM settings could not be queried.
 
-# Prerequisite
-This extension makes use of Thomas Debesse's dpm-query (https://github.com/illwieckz/dpm-query/). You will have to install it first.
 
-# Installation
+Prerequisite
+------------
+
+This extension makes use of Thomas Debesse's [`dpm-query`](https://github.com/illwieckz/dpm-query/). You will have to install it first. Only the tool is needed, the service is optionnal.
+
+
+Installation
+------------
+
 Download the files and cd into their directory (`git clone https://github.com/JuBan1/radeon-dpm-control.git` and `cd radeon-dpm-control`).
 
 Install via `sudo make install`.
@@ -17,7 +25,10 @@ Update your GNOME shell by restarting or pressing Alt+F2 and typing `r`.
 
 Enable the extension in your Tweak Tool.
 
-# Uninstallation
+
+Uninstallation
+--------------
+
 Disable the extension.
 
 Run `sudo make uninstall` in the same location.

--- a/src/radeon-dpm-control@s3rius/extension.js
+++ b/src/radeon-dpm-control@s3rius/extension.js
@@ -24,6 +24,7 @@ function enable()
 {
   dpmc = new DPMControl();
 }
+
 function disable()
 {
     dpmc.destroy();
@@ -43,9 +44,9 @@ PopupIconMenuItem.prototype =
     {
         PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
 
-        this.box = new St.BoxLayout({ style_class: 'popup-combobox-item' });
+        this.box = new St.BoxLayout({ style_class: "popup-combobox-item" });
 
-        this.icon = new St.Icon({ gicon: gicon, style_class: 'popup-menu-icon' });
+        this.icon = new St.Icon({ gicon: gicon, style_class: "popup-menu-icon" });
         this.box.add(this.icon);
 
         this.label = new St.Label({ text: text });
@@ -55,7 +56,8 @@ PopupIconMenuItem.prototype =
         this.actor.add(this.box);
     },
 
-    _onDestroy: function(){
+    _onDestroy: function()
+    {
         this.menu.removeAll();
     }
 };
@@ -73,19 +75,23 @@ DPMControl.prototype =
     {
         PanelMenu.Button.prototype._init.call(this, 0);
 
-        this._iconActor = new St.Icon({ icon_name: 'radeon-control-green',
-                                        style_class: 'system-status-icon' });
+        this._iconActor = new St.Icon({ icon_name: "radeon-control-green",
+                                        style_class: "system-status-icon" });
 
         this.actor.add_actor(this._iconActor);
-        this.actor.add_style_class_name('panel-status-button');
+        this.actor.add_style_class_name("panel-status-button");
 
         this._display();
 
-        Main.panel.addToStatusArea('radeon-dpm-control', this);
+        Main.panel.addToStatusArea("radeon-dpm-control", this);
     },
 
-    _updateIcon: function(){
-        [res,pid,fdin,fdout,fderr] = GLib.spawn_async_with_pipes(null, ["/usr/bin/dpm-query", "get", "default"], null, GLib.SpawnFlags.SEARCH_PATH, null);
+    _updateIcon: function()
+    {
+        let dpmquery_path = GLib.find_program_in_path("dpm-query");
+
+        [res, pid, fdin, fdout, fderr] = GLib.spawn_async_with_pipes(null, [dpmquery_path, "get", "default"],
+                                                                     null, GLib.SpawnFlags.SEARCH_PATH, null);
         let outstream = new Gio.UnixInputStream({fd:fdout,close_fd:true});
         let stdout = new Gio.DataInputStream({base_stream: outstream});
 
@@ -98,52 +104,73 @@ DPMControl.prototype =
         else {
             let result = out.toString() + out2.toString();
             
-            if( result.search("low") != -1 && result.search("battery") != -1 ){
+            if( result.search("\"low\"") != -1 && result.search("\"battery\"") != -1 ){
                 this._iconActor.icon_name = "radeon-control-green";
-            } else if( result.search("auto") != -1 && result.search("balanced") != -1 ) {
+            } else if( result.search("\"auto\"") != -1 && result.search("\"balanced\"") != -1 ) {
                 this._iconActor.icon_name = "radeon-control-yellow";
-            } else if( result.search("high") != -1 && result.search("\"performance\"") != -1 ) {
+            } else if( result.search("\"high\"") != -1 && result.search("\"performance\"") != -1 ) {
                 this._iconActor.icon_name = "radeon-control-red";
             } else{ 
                 this._iconActor.icon_name = "radeon-control-other";
             }
         }
-
     },
 
    _display: function()
    {
         this._updateIcon();
 
-        let gicon = Gio.content_type_get_icon('radeon-control-green');
+        let gicon = Gio.content_type_get_icon("radeon-control-green");
         let menuItem = new PopupIconMenuItem(gicon, " Set Low/Battery", {});
         this.menu.addMenuItem(menuItem);
-        menuItem.connect('activate', Lang.bind(this, this._setDPM, 'low battery'));
+        menuItem.connect("activate", Lang.bind(this, this._setDPM, ["low", "battery"]));
 
-        let gicon = Gio.content_type_get_icon('radeon-control-yellow');
+        let gicon = Gio.content_type_get_icon("radeon-control-yellow");
         let menuItem = new PopupIconMenuItem(gicon, " Set Auto/Balanced", {});
         this.menu.addMenuItem(menuItem);
-        menuItem.connect('activate', Lang.bind(this, this._setDPM, 'auto balanced'));
+        menuItem.connect("activate", Lang.bind(this, this._setDPM, ["auto", "balanced"]));
 
-        let gicon = Gio.content_type_get_icon('radeon-control-red');
+        let gicon = Gio.content_type_get_icon("radeon-control-red");
         let menuItem = new PopupIconMenuItem(gicon, " Set High/Performance", {});
         this.menu.addMenuItem(menuItem);
-        menuItem.connect('activate', Lang.bind(this, this._setDPM, 'high performance'));
+        menuItem.connect("activate", Lang.bind(this, this._setDPM, ["high", "performance"]));
 
         event = GLib.timeout_add_seconds(0, 5, Lang.bind(this, function () {
             this._updateIcon();
             return true;
         }));
-
-
     },
 
-    //This code was taken and modified from:
-    //http://stackoverflow.com/questions/10099593/gnome-shell-privilege-escalation
-    _setDPM: function(a,b,setting)
+    // This code was taken and modified from:
+    // http://stackoverflow.com/questions/10099593/gnome-shell-privilege-escalation
+    _setDPM: function(a, b, settings)
     {
-        let pkexec_path = GLib.find_program_in_path('pkexec');
-        let result = Util.trySpawnCommandLine(pkexec_path + " /usr/bin/dpm-query set default " + setting);
-    },
+        let dpmquery_path = GLib.find_program_in_path("dpm-query");
+        let pkexec_path = GLib.find_program_in_path("pkexec");
 
+        [res, pid, fdin, fdout, fderr] = GLib.spawn_async_with_pipes(null, [dpmquery_path, "test", "default"],
+                                                                     null, GLib.SpawnFlags.SEARCH_PATH, null);
+        let outstream = new Gio.UnixInputStream({fd:fdout,close_fd:true});
+        let stdout = new Gio.DataInputStream({base_stream: outstream});
+
+        let [out, size] = stdout.read_line(null);
+
+        if(out == null) {
+            this._iconActor.icon_name = "radeon-control-error";
+        }
+        else {
+            let result = out.toString();
+            if(result.search("forbidden") == -1) {
+                [res, pid] = GLib.spawn_async_with_pipes(null, [dpmquery_path, "set", "default"].concat(settings),
+                                                         null, GLib.SpawnFlags.SEARCH_PATH, null);
+                GLib.spawn_close_pid(pid);
+            }
+            else {
+                [res, pid] = GLib.spawn_async_with_pipes(null, [pkexec_path, dpmquery_path, "set", "default"].concat(settings),
+                                                         null, GLib.SpawnFlags.SEARCH_PATH, null);
+                GLib.spawn_close_pid(pid);
+            }
+        }
+        GLib.spawn_close_pid(pid);
+    },
 };

--- a/src/radeon-dpm-control@s3rius/extension.js
+++ b/src/radeon-dpm-control@s3rius/extension.js
@@ -85,7 +85,7 @@ DPMControl.prototype =
     },
 
     _updateIcon: function(){
-        [res,pid,fdin,fdout,fderr] = GLib.spawn_async_with_pipes(null, ["/usr/bin/dpm-query", "get", "all"], null, GLib.SpawnFlags.SEARCH_PATH, null);
+        [res,pid,fdin,fdout,fderr] = GLib.spawn_async_with_pipes(null, ["/usr/bin/dpm-query", "get", "default"], null, GLib.SpawnFlags.SEARCH_PATH, null);
         let outstream = new Gio.UnixInputStream({fd:fdout,close_fd:true});
         let stdout = new Gio.DataInputStream({base_stream: outstream});
 
@@ -143,7 +143,7 @@ DPMControl.prototype =
     _setDPM: function(a,b,setting)
     {
         let pkexec_path = GLib.find_program_in_path('pkexec');
-        let result = Util.trySpawnCommandLine(pkexec_path + " /usr/bin/dpm-query set all " + setting);
+        let result = Util.trySpawnCommandLine(pkexec_path + " /usr/bin/dpm-query set default " + setting);
     },
 
 };

--- a/src/radeon-dpm-control@s3rius/extension.js
+++ b/src/radeon-dpm-control@s3rius/extension.js
@@ -85,7 +85,7 @@ DPMControl.prototype =
     },
 
     _updateIcon: function(){
-        [res,pid,fdin,fdout,fderr] = GLib.spawn_async_with_pipes(null, ["/bin/dpm-query", "get", "all"], null, GLib.SpawnFlags.SEARCH_PATH, null);
+        [res,pid,fdin,fdout,fderr] = GLib.spawn_async_with_pipes(null, ["/usr/bin/dpm-query", "get", "all"], null, GLib.SpawnFlags.SEARCH_PATH, null);
         let outstream = new Gio.UnixInputStream({fd:fdout,close_fd:true});
         let stdout = new Gio.DataInputStream({base_stream: outstream});
 
@@ -143,7 +143,7 @@ DPMControl.prototype =
     _setDPM: function(a,b,setting)
     {
         let pkexec_path = GLib.find_program_in_path('pkexec');
-        let result = Util.trySpawnCommandLine(pkexec_path + " /bin/dpm-query set all " + setting);
+        let result = Util.trySpawnCommandLine(pkexec_path + " /usr/bin/dpm-query set all " + setting);
     },
 
 };

--- a/src/radeon-dpm-control@s3rius/metadata.json
+++ b/src/radeon-dpm-control@s3rius/metadata.json
@@ -1,1 +1,11 @@
-{"uuid": "radeon-dpm-control@s3rius", "shell-version": ["3.16", "3.18", "3.18.3"], "description": "A small extension to manually change Radeon's DPM settings.", "name": "Radeon DPM Control"}
+{
+  "name": "Radeon DPM Control",
+  "description": "A small extension to manually change Radeon's DPM settings.",
+  "uuid": "radeon-dpm-control@s3rius",
+  "extension-id": "radeon-dpm-control",
+  "url": "https://github.com/JuBan1/radeon-dpm-control",
+  "shell-version": [
+    "3.16",
+    "3.18"
+  ]
+}


### PR DESCRIPTION
Hi, this PR
- fixes the `dpm-query` call that broken the extension before
- calls `dpm-query test` to know if pkexec is needed (and do not use it if not needed)
- use `default` card list instead of `all` if user have defined a config file (`dpm-tool` defaults to all if default is not set)
- enhance the README with better markdown wording (screenshot display and inline links etc.)

Since the project is missing a proper license (see #2), I place these changes under the very permissive [ISC License](https://raw.githubusercontent.com/illwieckz/dpm-query/master/COPYING.md) so you can relicense it to the license you want for inclusion in your own project.

Thanks.
