### PR TITLE
enable 3.20 shell support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/JuBan1/radeon-dpm-control",
   "shell-version": [
     "3.16",
-    "3.18"
+    "3.18",
+    "3.20"
   ]
 }


### PR DESCRIPTION
It works unmodified in 3.20, so I just bumped the shell version.
